### PR TITLE
Remove 'data' from Octokit query access

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
                   label: 'CI-long-timeout'
                 }
               )
-              long_pr_count = response.data.repository.pullRequests.totalCount
+              long_pr_count = response.repository.pullRequests.totalCount
               core.notice('GraphQL query succeeded.')
               core.notice(`${long_pr_count} long PRs in Homebrew/core`)
             } catch (error) {


### PR DESCRIPTION
When Octokit makes GraphQL queries, it reads the "data" property for you, so this should read `response.repository` instead of `response.data.repository`.

I believe this will fix this issue outlined in https://github.com/actions/github-script/issues/230.